### PR TITLE
chore(refresh): refreshed configuration and documentation

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -114,7 +114,7 @@ Since this project is discontinued and has no CI/CD pipeline:
 - **UI:** XIB files for view layout — do not introduce programmatic layout or Storyboards.
 - **Data source:** Add new menu entries to `OptionsList.plist` — do not hardcode entries in view controllers.
 - **Types:** Use `DWORD` (`unsigned long`) for keygen intermediate computations to match original 32-bit target semantics.
-- **Formatting:** Follow existing Objective-C code style in the project (2-space indentation, method names in camelCase).
+- **Formatting:** Follow existing Objective-C code style in the project (4-space indentation, method names in camelCase).
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@ Exceptions are acceptable depending on the circumstances (critical bug fixes tha
 
 ### Changed
 
+- refreshed `.github/copilot-instructions.md` to fix incorrect indentation convention (2-space → 4-space)
+
 ### Removed
 
 


### PR DESCRIPTION
Automated weekly refresh by `config-and-docs-refresh.yaml` in `rios0rios0/config-automation`.

Claude Code reviewed the in-scope configuration and documentation files (currently `CLAUDE.md` and `.github/copilot-instructions.md`) against the current code, updated whichever drifted, and recorded the change in `CHANGELOG.md` (when the repo has one).

Review the diff carefully --- this PR was generated by Claude Code and may contain inaccuracies.