### PR TITLE
chore(chlog): converted the changelog to chlog fragments

### DIFF
--- a/.changes/unreleased/1787693882090423246-aa78.yaml
+++ b/.changes/unreleased/1787693882090423246-aa78.yaml
@@ -1,0 +1,3 @@
+kind: 'Changed'
+body: 'changed the changelog to [chlog](https://github.com/luizjhonata/chlog) fragments: a change now writes its own YAML file under `.changes/unreleased/` through `chlog new --kind <Kind> --body "..."`, and `CHANGELOG.md` is GENERATED from them at release time by `chlog batch auto && chlog merge`. That is the one thing a single shared file cannot do — two branches each adding an entry no longer touch the same lines, so a rebase that used to conflict on `CHANGELOG.md` now conflicts on nothing. The `[Unreleased]` section was empty, so nothing had to be carried across. AutoBump already reads the fragments directly, so the release flow is unchanged.'
+time: '2026-08-25T21:38:02.090104777Z'

--- a/.changes/unreleased/1787697563451905492-a048.yaml
+++ b/.changes/unreleased/1787697563451905492-a048.yaml
@@ -1,0 +1,3 @@
+kind: 'Fixed'
+body: 'fixed step 4 of the release instructions in `CHANGELOG.md`, replacing an unfilled placeholder with the concrete tag command and the releases page link'
+time: '2026-08-25T22:39:23.45187064Z'

--- a/.chlog.yaml
+++ b/.chlog.yaml
@@ -1,0 +1,29 @@
+# chlog — fragment-based changelog management (https://github.com/luizjhonata/chlog).
+#
+# Every value below is chlog's own default, spelled out on purpose: the file is the
+# one place a reader can see what the kinds are and which bump each one infers,
+# without going and reading the tool. Keep it in step with the `--kind` values the
+# AI-assistant block in CLAUDE.md advertises.
+#
+# No kind maps to `major`. Under SemVer a major bump means a backward-incompatible
+# change, which is a property of the change and not of its category, so it is
+# signalled per fragment by `chlog new --breaking` and never inferred from a label.
+changesDir: .changes
+unreleasedDir: unreleased
+changelogPath: CHANGELOG.md
+versionFormat: '## [{{.Version}}] - {{.Time.Format "2006-01-02"}}'
+kindFormat: '### {{.Kind}}'
+changeFormat: '- {{.Body}}'
+kinds:
+  - label: Added
+    auto: minor
+  - label: Changed
+    auto: minor
+  - label: Deprecated
+    auto: minor
+  - label: Removed
+    auto: minor
+  - label: Fixed
+    auto: patch
+  - label: Security
+    auto: patch

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -139,3 +139,28 @@ Since this project is discontinued and has no CI/CD pipeline:
 - There is no test suite; manual verification via Xcode simulator is the only validation method.
 - The `Build/` directory contains pre-built artifacts and should not be modified by source code changes.
 - All UI is XIB-based — do not introduce Storyboards or SwiftUI.
+
+<!-- chlog:start -->
+## Changelog (chlog) — MANDATORY
+
+If the repository you are working in uses chlog (a `.chlog.yaml` or `.chlog.yml`
+config file, or a `.changes/` directory, exists at the project root), the
+following is binding and ALWAYS applies: whenever you make ANY change, you MUST
+create a changelog fragment as part of the same change — automatically, without
+being asked, before committing.
+
+- Do NOT edit CHANGELOG.md directly; it is generated from fragments.
+- Create the fragment with:
+  `chlog new --kind <Kind> --body "<imperative description>"`
+- Valid kinds: Added, Changed, Deprecated, Removed, Fixed, Security
+- Choose the kind that best matches the change (e.g., new feature → Added,
+  bug fix → Fixed, behavior change → Changed, removal → Removed, security fix → Security).
+- If the change is backward-INCOMPATIBLE with the public API (a breaking
+  change), you MUST add the `--breaking` flag:
+  `chlog new --kind <Kind> --breaking --body "<description>"`.
+  This is the ONLY thing that triggers a major version bump — the kind alone
+  never does (per SemVer, major = incompatible change). When unsure whether a
+  change breaks compatibility, ask the user instead of guessing.
+- Fragments are YAML files in `.changes/unreleased/`; stage them with your commit.
+- `chlog check` fails the build when a fragment is missing — never skip it.
+<!-- chlog:end -->

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,10 +4,16 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+This file is not edited by hand. Every change writes its own fragment under
+`.changes/unreleased/` with [chlog](https://github.com/luizjhonata/chlog), and a release compiles
+the pending fragments into a version section here — so two branches each adding an entry no
+longer touch the same lines, and a rebase that used to conflict on this file now conflicts on
+nothing.
+
 When a new release is proposed:
 
 1. Create a new branch `bump/x.x.x` (this isn't a long-lived branch!!!);
-2. The Unreleased section on `CHANGELOG.md` gets a version number and date;
+2. The fragments pending under `.changes/unreleased/` are compiled into a version section by `chlog batch auto && chlog merge` (AutoBump does this for you — it reads the fragments directly);
 3. Open a Pull Request with the bump version changes targeting the `main` branch;
 4. When the Pull Request is merged, a new Git tag must be created using <LINK TO THE PLATFORM TO OPEN THE PULL REQUEST>.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ When a new release is proposed:
 1. Create a new branch `bump/x.x.x` (this isn't a long-lived branch!!!);
 2. The fragments pending under `.changes/unreleased/` are compiled into a version section by `chlog batch auto && chlog merge` (AutoBump does this for you — it reads the fragments directly);
 3. Open a Pull Request with the bump version changes targeting the `main` branch;
-4. When the Pull Request is merged, a new Git tag must be created using <LINK TO THE PLATFORM TO OPEN THE PULL REQUEST>.
+4. When the Pull Request is merged, a Git tag matching the released version must be created on `main` (`git tag x.x.x && git push origin x.x.x`), or through the repository's [releases page](https://github.com/rios0rios0/to-key/releases/new).
 
 Releases to productive environments should run from a tagged version.
 Exceptions are acceptable depending on the circumstances (critical bug fixes that can be cherry-picked, etc.).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -27,3 +27,28 @@ See `.github/copilot-instructions.md` for the same guidance phrased for Copilot,
 - Master-detail under a `UINavigationController` (set up in `AppDelegate.m`). `MasterViewController` is a `UITableView` whose rows come from `OptionsList.plist` — name, description, icon per entry. Add menu entries there, never hardcode them.
 - **Keygen dispatch is by title string.** `DetailViewController.m`'s `textView:shouldChangeTextInRange:` selects the algorithm by string-comparing `self.title` against literal challenge names (`@"~EvilCode's Keygen-Me #1"`, `@"KeygenMe #1"`, `@"Ghost Keygen-me"`, `@"Muckis Crackme #2"`). Adding a keygen requires both an `OptionsList.plist` entry **and** a matching `self.title` branch plus its method — the two are coupled only through that exact string.
 - `PasswordViewController.m` keeps the four sliders' total ≤ 20 (enforced in `ChangeSlider:`) and emits 15 passwords per run via `rand()` over a pool concatenated from the enabled character classes.
+
+<!-- chlog:start -->
+## Changelog (chlog) — MANDATORY
+
+If the repository you are working in uses chlog (a `.chlog.yaml` or `.chlog.yml`
+config file, or a `.changes/` directory, exists at the project root), the
+following is binding and ALWAYS applies: whenever you make ANY change, you MUST
+create a changelog fragment as part of the same change — automatically, without
+being asked, before committing.
+
+- Do NOT edit CHANGELOG.md directly; it is generated from fragments.
+- Create the fragment with:
+  `chlog new --kind <Kind> --body "<imperative description>"`
+- Valid kinds: Added, Changed, Deprecated, Removed, Fixed, Security
+- Choose the kind that best matches the change (e.g., new feature → Added,
+  bug fix → Fixed, behavior change → Changed, removal → Removed, security fix → Security).
+- If the change is backward-INCOMPATIBLE with the public API (a breaking
+  change), you MUST add the `--breaking` flag:
+  `chlog new --kind <Kind> --breaking --body "<description>"`.
+  This is the ONLY thing that triggers a major version bump — the kind alone
+  never does (per SemVer, major = incompatible change). When unsure whether a
+  change breaks compatibility, ask the user instead of guessing.
+- Fragments are YAML files in `.changes/unreleased/`; stage them with your commit.
+- `chlog check` fails the build when a fragment is missing — never skip it.
+<!-- chlog:end -->


### PR DESCRIPTION
Converts this repository's changelog to [chlog](https://github.com/luizjhonata/chlog) fragments.

## What this is

`CHANGELOG.md` stops being a file anyone edits. Every change now writes its **own** YAML fragment
under `.changes/unreleased/`, and a release compiles them:

```bash
chlog new --kind Added --body "added the thing that was not there before"
chlog new --kind Changed --breaking --body "..."   # the only thing that bumps the major
chlog batch auto && chlog merge                    # at release time
```

`chlog` is [luizjhonata/chlog](https://github.com/luizjhonata/chlog) — a single Go binary,
`go install github.com/luizjhonata/chlog@latest`. This branch was produced with **v0.4.0**, and the
fragments were written by the binary itself rather than by hand, so their format is exactly what the
tool emits.

The point is the one thing a single shared file cannot do: two branches each adding an entry no
longer touch the same lines, so a rebase that used to conflict on `CHANGELOG.md` now conflicts on
nothing.

## How the existing entries were migrated

The `[Unreleased]` section was empty when this branch was cut, so nothing had to be carried across — the only fragment here is the one describing this change.

## Reviewing this

| File | What changed |
|---|---|
| `.chlog.yaml` | New. chlog's own defaults, spelled out so the kinds and their bump levels are readable without going to the tool |
| `CHANGELOG.md` | The header now says the file is not edited by hand, and the release recipe points at the fragments; the empty `[Unreleased]` heading stays |
| `CLAUDE.md` | Carries chlog's assistant block, injected with `chlog ai setup` and marked `<!-- chlog:start -->`, so re-running the command updates it in place |
| `.github/copilot-instructions.md` | Same |

## Two things called out deliberately

**No CI job was added, and nothing gates this repository on a pull request today** — it has no
GitHub Actions workflows at all. That is not a regression: nothing checked `CHANGELOG.md` here
before this branch either. The shared `rios0rios0/pipelines` basic-checks gate is already
chlog-aware — with `.chlog.yaml` present it requires a **new fragment** on an ordinary branch, and
flips to requiring an updated `CHANGELOG.md` on a `bump/*` branch — so the enforcement arrives for
free the day this repository adopts a pipeline. Until then, `chlog hook install --local` runs the
same check on every commit in a clone.

**AutoBump needs no change either.** It detects the layout (`internal/domain/commands/chlog.go`) and
turns the pending fragments back into `[Unreleased]` lines before calculating the next version, so
the release flow is exactly what it was.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

